### PR TITLE
local nuget config and setup script

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        <add key="dotnet-nightlies" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+        <add key="JackFruit" value="./LocalPackageSource" />
+    </packageSources>
+</configuration>

--- a/init.ps1
+++ b/init.ps1
@@ -1,0 +1,11 @@
+dotnet build Jackfruit.Runtime 
+dotnet pack Jackfruit.Runtime 
+foreach ($pkg in Get-ChildItem -Path "Jackfruit.Runtime/bin/Debug/Jackfruit.Runtime.*.nupkg") {
+    dotnet nuget push $pkg --source JackFruit
+}
+
+dotnet build .\Jackfruit.IncrementalGenerator
+dotnet pack .\Jackfruit.IncrementalGenerator
+foreach ($pkg in Get-ChildItem -Path "Jackfruit.IncrementalGenerator/bin/Debug/Jackfruit.IncrementalGenerator.*.nupkg") {
+    dotnet nuget push $pkg --source JackFruit
+}


### PR DESCRIPTION
This adds a NuGet.config and repo setup script to make it easier for users to get started in this repo.  Because the setup steps require publishing the runtime and generator package first to a local nuget feed, it was easier to get them setup one time.