### PR TITLE
make runtime/incremental generator something that can be iterated on locally without packagereferences

### DIFF
--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -7,9 +7,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Jackfruit.IncrementalGenerator" Version="0.0.1-alphaP" />
+	<ItemGroup Condition="'$(TestRelease)' == 'true'">
+		<PackageReference Condition="'$(TestRelease)' == 'true'" Include="Jackfruit.IncrementalGenerator" Version="0.0.1-alphaP" />
 	</ItemGroup>
+  <ItemGroup Condition="'$(TestRelease)' != 'true'">
+    <ProjectReference Include="../Jackfruit.IncrementalGenerator/Jackfruit.IncrementalGenerator.csproj" />
+    <ProjectReference Include="../Jackfruit.Runtime/Jackfruit.Runtime.csproj" />
+    <Analyzer Include="../Jackfruit.IncrementalGenerator/bin/Debug/netstandard2.0/Jackfruit.IncrementalGenerator.dll" />
+  </ItemGroup>
 
 
 </Project>

--- a/Jackfruit.IncrementalGenerator/Jackfruit.IncrementalGenerator.csproj
+++ b/Jackfruit.IncrementalGenerator/Jackfruit.IncrementalGenerator.csproj
@@ -23,10 +23,16 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Jackfruit.Runtime" Version="0.0.1-alphaG" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22222.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TestRelease)' == 'true'">
+		<PackageReference Include="Jackfruit.Runtime" Version="0.0.1-alphaG" />
+	</ItemGroup>
+  	<ItemGroup Condition="'$(TestRelease)' != 'true'">
+    	<ProjectReference Include="../Jackfruit.Runtime/Jackfruit.Runtime.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This was keyed off by our conversation today, @KathleenDollard. 

The idea is that in the released version, people do have to use PackageReferences, but when doing a simple `dotnet build` of the Example project, the defaults use a combination of ProjectReferences and manual wiring up of the `Analyzer` MSBuild item to ensure the analyzer generates as you expect.

The test matrix becomes:
* clone empty and dotnet build Example.csproj -> should compile out of the box
* make the local nuget source, pack and push runtime, pack and push incremental with `-p:TestRelease=true` set, `dotnet build Example.csproj -p:TestRelease=true` -> should also compile