### PR TITLE
Control runtime dependency

### DIFF
--- a/Jackfruit.IncrementalGenerator/Jackfruit.IncrementalGenerator.csproj
+++ b/Jackfruit.IncrementalGenerator/Jackfruit.IncrementalGenerator.csproj
@@ -23,10 +23,17 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Jackfruit.Runtime" Version="0.0.1-alphaG" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22222.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(Package)' == 'true'">
+		<PackageReference Include="Jackfruit.Runtime" Version="0.0.1-alphaG" />
+	</ItemGroup>
+	
+	<ItemGroup Condition="'$(Package)' != 'true'">
+		<ProjectReference Include="../Jackfruit.Runtime/Jackfruit.Runtime.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Jackfruit.IncrementalGenerator/Jackfruit.IncrementalGenerator.csproj
+++ b/Jackfruit.IncrementalGenerator/Jackfruit.IncrementalGenerator.csproj
@@ -28,11 +28,11 @@
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22222.1" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(Package)' == 'true'">
+	<ItemGroup Condition="'$(CreatePackage)' == 'true'">
 		<PackageReference Include="Jackfruit.Runtime" Version="0.0.1-alphaG" />
 	</ItemGroup>
 	
-	<ItemGroup Condition="'$(Package)' != 'true'">
+	<ItemGroup Condition="'$(CreatePackage)' != 'true'">
 		<ProjectReference Include="../Jackfruit.Runtime/Jackfruit.Runtime.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
From #33

I did a separate PR because I have removed Example.csproj. I think it should be more part of documentation. 