### PR TITLE
Rename CliNode to SubCommand

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
      <PropertyGroup> 
-		<PackageVersion>0.0.1-alphaU</PackageVersion>
-		<Version>0.0.1-alphaU</Version>
+		<PackageVersion>0.0.1-alphaV</PackageVersion>
+		<Version>0.0.1-alphaV</Version>
      </PropertyGroup>
 </Project>

--- a/Jackfruit.Common/CreateSource.cs
+++ b/Jackfruit.Common/CreateSource.cs
@@ -81,7 +81,7 @@ namespace Jackfruit.Common
                                     .Static()
                                     .NewSlot()
                                     .Parameters(
-                                        Parameter("rootNode", "CommandNode"))
+                                        Parameter("rootNode", "SubCommand"))
                                     .Statements(
                                         Return(Invoke("RootCommand<RootCommand, RootCommand.Result>",
                                              "Create",

--- a/Jackfruit.IncrementalGenerator/JackfruitGenerator.cs
+++ b/Jackfruit.IncrementalGenerator/JackfruitGenerator.cs
@@ -43,8 +43,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/Jackfruit.Runtime/CommandNode.cs
+++ b/Jackfruit.Runtime/CommandNode.cs
@@ -1,17 +1,17 @@
 ﻿namespace Jackfruit
 {
-    public class CommandNode
+    public class SubCommand
     {
         // I do not see a use case for exposing these
         internal Delegate Action { get; }
         internal Delegate? Validator { get; }
-        internal IEnumerable<CommandNode> SubCommands { get; }
+        internal IEnumerable<SubCommand> SubCommands { get; }
 
-        public static CommandNode Create(Delegate action, params CommandNode[] subCommands)
-        { return new CommandNode(action, subCommands); }
+        public static SubCommand Create(Delegate handlerAction, params SubCommand[] subCommands)
+        { return new SubCommand(handlerAction, subCommands); }
 
-        public static CommandNode Create(Delegate action, Delegate validator, params CommandNode[] subCommands)
-        { return new CommandNode(action,validator, subCommands); }
+        public static SubCommand Create(Delegate handlerAction, Delegate resultValidator, params SubCommand[] subCommands)
+        { return new SubCommand(handlerAction,resultValidator, subCommands); }
 
         /// <summary>
         /// Represents a single command in a CLI and contains the delegate that 
@@ -22,11 +22,11 @@
         /// This form is currently required for generation to work correctly (no lambdas).
         /// </param>
         /// <param name="subCommands">CliNodes for the subcommands of the command</param>
-        public CommandNode(Delegate action, params CommandNode[] subCommands) 
+        public SubCommand(Delegate action, params SubCommand[] subCommands) 
             : this (action, null, subCommands)
         { }
 
-        public CommandNode(Delegate action, Delegate? validator, params CommandNode[] subCommands)
+        public SubCommand(Delegate action, Delegate? validator, params SubCommand[] subCommands)
         {
             Action = action;
             Validator = validator;

--- a/Jackfruit.Runtime/GeneratedCommandBase.cs
+++ b/Jackfruit.Runtime/GeneratedCommandBase.cs
@@ -35,7 +35,7 @@ namespace Jackfruit.Internal
     public abstract class RootCommand<T, TResult> : GeneratedCommandBase<T, TResult>
         where T : RootCommand<T, TResult>, new()
     {
-        public static RootCommand<T, TResult> Create(CommandNode cliRoot)
+        public static RootCommand<T, TResult> Create(SubCommand cliRoot)
         { return new T(); }
 
         public int Run(string[] args) 

--- a/Jackfruit.TestSupport/IntegrationTestConfiguration.cs
+++ b/Jackfruit.TestSupport/IntegrationTestConfiguration.cs
@@ -56,7 +56,5 @@ namespace Jackfruit.TestSupport
             Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary;
 
         public int? SyntaxTreeCount { get; set; } = null;
-
-        public string[] SourceFiles { get; set; } = Array.Empty<string>();
     }
 }

--- a/Jackfruit.TestSupport/TestHelpers.cs
+++ b/Jackfruit.TestSupport/TestHelpers.cs
@@ -91,28 +91,16 @@ public class TestHelpers
         return (compilation, inputDiagnostics);
     }
 
-    public static void OutputGeneratedTrees(Compilation generatedCompilation, string outputDir, params string[] skipFiles)
+    public static void OutputGeneratedTrees(Compilation generatedCompilation, string outputDir)
     {
+        // the presence of a file path is used to indicate generated. this feels weak.
         foreach (var tree in generatedCompilation.SyntaxTrees)
         {
-            var className = !string.IsNullOrWhiteSpace(tree.FilePath)
-                    ? Path.GetFileName(tree.FilePath)
-                    : ClassName(tree.GetRoot()
-                        .DescendantNodes()
-                        .OfType<ClassDeclarationSyntax>());
-            if (string.IsNullOrWhiteSpace(className) || 
-                skipFiles.Contains(className) || 
-                skipFiles.Contains(Path.GetFileNameWithoutExtension(className)))
-            { continue; }
-            var fileName = Path.Combine(outputDir, className);
+            if (string.IsNullOrWhiteSpace(tree.FilePath))
+                { continue; }
+            var fileName = Path.Combine(outputDir, Path.GetFileName(tree.FilePath));
             File.WriteAllText(fileName, tree.ToString());
         }
-
-        static string? ClassName(IEnumerable<ClassDeclarationSyntax> classes)
-            => classes.Any()
-                ? classes.First()
-                         .Identifier.ToString() + ".cs"
-                : null;
     }
 
     public static Process? CompileOutput(string testInputPath)

--- a/Jackfruit.Tests/CommandDefCliTests.cs
+++ b/Jackfruit.Tests/CommandDefCliTests.cs
@@ -19,7 +19,7 @@ using System.ComponentModel;
 
 public partial class RootCommand
 {{
-    public static RootCommand Create(params CommandNode[] cliRoot)
+    public static RootCommand Create(params SubCommand[] cliRoot)
         => new RootCommand();
 }}
 
@@ -43,7 +43,7 @@ public class MyClass
             var input = methodWrapper(@"
     public void Test()
     {
-       var rootCommand = RootCommand.Create(CommandNode.Create(A));
+       var rootCommand = RootCommand.Create(SubCommand.Create(A));
     }");
             var (inputDiagnostics,diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -58,8 +58,8 @@ public class MyClass
             var input = methodWrapper(@"
     public void Test()
     {
-       var rootCommand = RootCommand.Create(CommandNode.Create(A, 
-            CommandNode.Create(B)));
+       var rootCommand = RootCommand.Create(SubCommand.Create(A, 
+            SubCommand.Create(B)));
     }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -74,10 +74,10 @@ public class MyClass
             var input = methodWrapper(@"
     public void Test() 
     {
-       var rootCommand = RootCommand.Create(CommandNode.Create(A, 
-            CommandNode.Create(B),
-            CommandNode.Create(C),
-            CommandNode.Create(D)));
+       var rootCommand = RootCommand.Create(SubCommand.Create(A, 
+            SubCommand.Create(B),
+            SubCommand.Create(C),
+            SubCommand.Create(D)));
     }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -92,14 +92,14 @@ public class MyClass
             var input = methodWrapper(@"
     public void Test() 
     {
-       var rootCommand = RootCommand.Create(CommandNode.Create(A, 
-            CommandNode.Create(B),
-            CommandNode.Create(C,
-                CommandNode.Create(E),
-                CommandNode.Create(F,
-                    CommandNode.Create(G),
-                    CommandNode.Create(H))),
-            CommandNode.Create(D)));
+       var rootCommand = RootCommand.Create(SubCommand.Create(A, 
+            SubCommand.Create(B),
+            SubCommand.Create(C,
+                SubCommand.Create(E),
+                SubCommand.Create(F,
+                    SubCommand.Create(G),
+                    SubCommand.Create(H))),
+            SubCommand.Create(D)));
     }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -114,16 +114,16 @@ public class MyClass
             var input = methodWrapper(@"
     public void Test() 
     {
-        var rootCommand = RootCommand.Create(CommandNode.Create(A, 
-                CommandNode.Create(B),
-                CommandNode.Create(C,  
-                    CommandNode.Create(E),
-                    CommandNode.Create(F,
-                        CommandNode.Create(G), 
-                        CommandNode.Create(H)
+        var rootCommand = RootCommand.Create(SubCommand.Create(A, 
+                SubCommand.Create(B),
+                SubCommand.Create(C,  
+                    SubCommand.Create(E),
+                    SubCommand.Create(F,
+                        SubCommand.Create(G), 
+                        SubCommand.Create(H)
                     )
                 ),
-                CommandNode.Create(D)
+                SubCommand.Create(D)
             ));
     }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
@@ -138,7 +138,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(null));
+            var rootCommand = RootCommand.Create(SubCommand.Create(null));
         }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -153,7 +153,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.CreateX(CommandNode.Create(A));
+            var rootCommand = RootCommand.CreateX(SubCommand.Create(A));
         }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -183,7 +183,7 @@ public class MyClass
         var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         [Description(""Command description in Attribute"")]
@@ -225,7 +225,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         public void AA(
@@ -244,7 +244,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         public void AA(
@@ -264,7 +264,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         public void AA(
@@ -283,7 +283,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         public void AA(
@@ -303,7 +303,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         [Aliases(""C1"")]
@@ -323,7 +323,7 @@ public class MyClass
             var input = methodWrapper(@"
         public void Test()
         {
-            var rootCommand = RootCommand.Create(CommandNode.Create(AA));
+            var rootCommand = RootCommand.Create(SubCommand.Create(AA));
         }
 
         public void AA(

--- a/Jackfruit.Tests/CommandDefValidatorTests.cs
+++ b/Jackfruit.Tests/CommandDefValidatorTests.cs
@@ -17,7 +17,7 @@ using Jackfruit;
 
 public partial class RootCommand
 {{
-    public static RootCommand Create(CommandNode cliRoot)
+    public static RootCommand Create(SubCommand cliRoot)
         => new RootCommand();
 }}
 
@@ -37,7 +37,7 @@ public class MyClass
             var input = MethodWrapper(@"
     public void Test()
     {
-       var rootCommand = RootCommand.Create(CommandNode.Create( ToValidate, Validator1));
+       var rootCommand = RootCommand.Create(SubCommand.Create( ToValidate, Validator1));
     }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -52,7 +52,7 @@ public class MyClass
             var input = MethodWrapper(@"
             public void Test()
             {
-               var rootCommand = RootCommand.Create(CommandNode.Create( ToValidate, ValidatorAll));
+               var rootCommand = RootCommand.Create(SubCommand.Create( ToValidate, ValidatorAll));
             }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 
@@ -67,7 +67,7 @@ public class MyClass
             var input = MethodWrapper(@"
             public void Test()
             {
-               var rootCommand = RootCommand.Create(CommandNode.Create( ToValidate, Validator0));
+               var rootCommand = RootCommand.Create(SubCommand.Create( ToValidate, Validator0));
             }");
             var (inputDiagnostics, diagnostics, output) = TestHelpers.GetGeneratedOutput<CommandDefGenerator>(input);
 

--- a/Jackfruit.Tests/IntegrationTests.cs
+++ b/Jackfruit.Tests/IntegrationTests.cs
@@ -13,22 +13,19 @@ namespace Jackfruit.Tests
         private readonly IntegrationTestConfiguration testOutputExampleConfiguration =
             new("TestOutputExample")
             {
-                OutputKind = OutputKind.ConsoleApplication,
-                SourceFiles = new string[] { "Handlers.cs", "Validators.cs", "Program.cs" }
+                OutputKind = OutputKind.ConsoleApplication 
             };
 
         private readonly IntegrationTestConfiguration testOutputEmptyConfiguration =
             new("TestOutputEmpty")
             {
-                OutputKind = OutputKind.ConsoleApplication,
-                SourceFiles = new string[] { "Program.cs" }
+                OutputKind = OutputKind.ConsoleApplication
             };
 
         private readonly IntegrationTestConfiguration testOutputSimpleConfiguration =
             new("TestOutputSimple")
             {
-                OutputKind = OutputKind.ConsoleApplication,
-                SourceFiles = new string[] { "Program.cs", "Class1.cs" }
+                OutputKind = OutputKind.ConsoleApplication
             };
 
 

--- a/Jackfruit.Tests/StarTrekCliTests.cs
+++ b/Jackfruit.Tests/StarTrekCliTests.cs
@@ -33,7 +33,7 @@ public class MyClass
 {
     public void F() 
     {
-        var rootCommand = RootCommand.Create(CommandNode.Create(Handlers.Voyager));
+        var rootCommand = RootCommand.Create(SubCommand.Create(Handlers.Voyager));
     }
 
 }";
@@ -46,11 +46,11 @@ public class MyClass
 {
     public void F() 
     {
-        var rootCommand = RootCommand.Create(CommandNode.Create(Handlers.Franchise, 
-            CommandNode.Create(Handlers.StarTrek, 
-                CommandNode.Create(Handlers.NextGeneration, 
-                    CommandNode.Create(Handlers.DeepSpaceNine),
-                    CommandNode.Create(Handlers.Voyager) 
+        var rootCommand = RootCommand.Create(SubCommand.Create(Handlers.Franchise, 
+            SubCommand.Create(Handlers.StarTrek, 
+                SubCommand.Create(Handlers.NextGeneration, 
+                    SubCommand.Create(Handlers.DeepSpaceNine),
+                    SubCommand.Create(Handlers.Voyager) 
                 ))));
 
         var nextGen = cliRoot.StarTrekCommand.NextGenerationCommand.Create();
@@ -70,11 +70,11 @@ public class MyClass
 {
     public void F() 
     {
-        var rootCommand = RootCommand.Create(CommandNode.Create(Handlers.Franchise, Validators.FranchiseValidate,
-            CommandNode.Create(Handlers.StarTrek, 
-                CommandNode.Create(Handlers.NextGeneration, 
-                    CommandNode.Create(Handlers.DeepSpaceNine),
-                    CommandNode.Create(Handlers.Voyager) 
+        var rootCommand = RootCommand.Create(SubCommand.Create(Handlers.Franchise, Validators.FranchiseValidate,
+            SubCommand.Create(Handlers.StarTrek, 
+                SubCommand.Create(Handlers.NextGeneration, 
+                    SubCommand.Create(Handlers.DeepSpaceNine),
+                    SubCommand.Create(Handlers.Voyager) 
                 ))));
 
         var nextGen = cliRoot.StarTrekCommand.NextGenerationCommand.Create();
@@ -95,7 +95,7 @@ public class MyClass
 {
     public void F() 
     {
-        var rootCommand = RootCommand.Create(CommandNode.Create(Handlers.NextGeneration));
+        var rootCommand = RootCommand.Create(SubCommand.Create(Handlers.NextGeneration));
     }
 
 }";

--- a/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_NextGeneration.verified.txt
+++ b/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_NextGeneration.verified.txt
@@ -10,8 +10,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_StarTrek.verified.txt
+++ b/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_StarTrek.verified.txt
@@ -10,8 +10,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_StarTrekRootWithValidator.verified.txt
+++ b/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_StarTrekRootWithValidator.verified.txt
@@ -10,8 +10,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_Voyager.verified.txt
+++ b/Jackfruit.Tests/StarTrekSnapshots/StartTrekCliTests.Can_Generate_Voyager.verified.txt
@@ -10,8 +10,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/TestOutputEmpty/GeneratedViaTest/RootCommand.partial.g.cs
+++ b/TestOutputEmpty/GeneratedViaTest/RootCommand.partial.g.cs
@@ -10,8 +10,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/TestOutputExample/GeneratedViaTest/DemoHandlersDeepSpaceNine.g.cs
+++ b/TestOutputExample/GeneratedViaTest/DemoHandlersDeepSpaceNine.g.cs
@@ -72,7 +72,7 @@ namespace Jackfruit_DemoHandlers
       public int Invoke(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.DeepSpaceNine(result.Greeting, result.Sisko, result.Odo, result.Dax, result.Worf, result.OBrien);
+         DemoHandlers.RunHandlers.DeepSpaceNine(result.Greeting, result.Sisko, result.Odo, result.Dax, result.Worf, result.OBrien);
          return invocationContext.ExitCode;
       }
       
@@ -83,7 +83,7 @@ namespace Jackfruit_DemoHandlers
       public Task<int> InvokeAsync(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.DeepSpaceNine(result.Greeting, result.Sisko, result.Odo, result.Dax, result.Worf, result.OBrien);
+         DemoHandlers.RunHandlers.DeepSpaceNine(result.Greeting, result.Sisko, result.Odo, result.Dax, result.Worf, result.OBrien);
          return Task.FromResult(invocationContext.ExitCode);
       }
       

--- a/TestOutputExample/GeneratedViaTest/DemoHandlersNextGeneration.g.cs
+++ b/TestOutputExample/GeneratedViaTest/DemoHandlersNextGeneration.g.cs
@@ -62,7 +62,7 @@ namespace Jackfruit_DemoHandlers
       public int Invoke(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.NextGeneration(result.Greeting, result.Picard);
+         DemoHandlers.RunHandlers.NextGeneration(result.Greeting, result.Picard);
          return invocationContext.ExitCode;
       }
       
@@ -73,7 +73,7 @@ namespace Jackfruit_DemoHandlers
       public Task<int> InvokeAsync(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.NextGeneration(result.Greeting, result.Picard);
+         DemoHandlers.RunHandlers.NextGeneration(result.Greeting, result.Picard);
          return Task.FromResult(invocationContext.ExitCode);
       }
       

--- a/TestOutputExample/GeneratedViaTest/DemoHandlersRootCommand.g.cs
+++ b/TestOutputExample/GeneratedViaTest/DemoHandlersRootCommand.g.cs
@@ -57,7 +57,7 @@ namespace Jackfruit
       public int Invoke(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.Franchise(result.Greeting);
+         DemoHandlers.RunHandlers.Franchise(result.Greeting);
          return invocationContext.ExitCode;
       }
       
@@ -68,7 +68,7 @@ namespace Jackfruit
       public Task<int> InvokeAsync(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.Franchise(result.Greeting);
+         DemoHandlers.RunHandlers.Franchise(result.Greeting);
          return Task.FromResult(invocationContext.ExitCode);
       }
       
@@ -80,7 +80,7 @@ namespace Jackfruit
       {
          base.Validate(invocationContext);
          var result = Result.GetResult(this, invocationContext);
-         var err = string.Join(Environment.NewLine, DemoHandlers.Validators.FranchiseValidate(result.Greeting));
+         var err = string.Join(Environment.NewLine, DemoHandlers.ResultValidators.FranchiseValidate(result.Greeting));
          if (!(string.IsNullOrWhiteSpace(err)))
          {
             invocationContext.ParseResult.CommandResult.ErrorMessage = err;

--- a/TestOutputExample/GeneratedViaTest/DemoHandlersStarTrek.g.cs
+++ b/TestOutputExample/GeneratedViaTest/DemoHandlersStarTrek.g.cs
@@ -69,7 +69,7 @@ namespace Jackfruit_DemoHandlers
       public int Invoke(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.StarTrek(result.Greeting, result.Kirk, result.Spock, result.Uhura);
+         DemoHandlers.RunHandlers.StarTrek(result.Greeting, result.Kirk, result.Spock, result.Uhura);
          return invocationContext.ExitCode;
       }
       
@@ -80,7 +80,7 @@ namespace Jackfruit_DemoHandlers
       public Task<int> InvokeAsync(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.StarTrek(result.Greeting, result.Kirk, result.Spock, result.Uhura);
+         DemoHandlers.RunHandlers.StarTrek(result.Greeting, result.Kirk, result.Spock, result.Uhura);
          return Task.FromResult(invocationContext.ExitCode);
       }
       

--- a/TestOutputExample/GeneratedViaTest/DemoHandlersVoyager.g.cs
+++ b/TestOutputExample/GeneratedViaTest/DemoHandlersVoyager.g.cs
@@ -73,7 +73,7 @@ namespace Jackfruit_DemoHandlers
       public int Invoke(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.Voyager(result.Console, result.Greeting, result.Janeway, result.Chakotay, result.Torres, result.Tuvok, result.SevenOfNine);
+         DemoHandlers.RunHandlers.Voyager(result.Console, result.Greeting, result.Janeway, result.Chakotay, result.Torres, result.Tuvok, result.SevenOfNine);
          return invocationContext.ExitCode;
       }
       
@@ -84,7 +84,7 @@ namespace Jackfruit_DemoHandlers
       public Task<int> InvokeAsync(InvocationContext invocationContext)
       {
          var result = Result.GetResult(this, invocationContext);
-         DemoHandlers.Handlers.Voyager(result.Console, result.Greeting, result.Janeway, result.Chakotay, result.Torres, result.Tuvok, result.SevenOfNine);
+         DemoHandlers.RunHandlers.Voyager(result.Console, result.Greeting, result.Janeway, result.Chakotay, result.Torres, result.Tuvok, result.SevenOfNine);
          return Task.FromResult(invocationContext.ExitCode);
       }
       

--- a/TestOutputExample/GeneratedViaTest/RootCommand.partial.g.cs
+++ b/TestOutputExample/GeneratedViaTest/RootCommand.partial.g.cs
@@ -10,8 +10,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/TestOutputExample/Program.cs
+++ b/TestOutputExample/Program.cs
@@ -6,11 +6,11 @@ internal class Program
     private static void Main(string[] args)
     {
         var rootCommand = RootCommand.Create(
-           CommandNode.Create(Handlers.Franchise, Validators.FranchiseValidate,
-              CommandNode.Create(Handlers.StarTrek,
-                 CommandNode.Create(Handlers.NextGeneration,
-                     CommandNode.Create(Handlers.DeepSpaceNine),
-                     CommandNode.Create(Handlers.Voyager)
+           SubCommand.Create(RunHandlers.Franchise, ResultValidators.FranchiseValidate,
+              SubCommand.Create(RunHandlers.StarTrek,
+                 SubCommand.Create(RunHandlers.NextGeneration,
+                     SubCommand.Create(RunHandlers.DeepSpaceNine),
+                     SubCommand.Create(RunHandlers.Voyager)
                  ))));
         rootCommand.GreetingArgument.SetDefaultValue("Hello"); 
         rootCommand.Run(args);

--- a/TestOutputExample/ResultValidators.cs
+++ b/TestOutputExample/ResultValidators.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace DemoHandlers
 {
-    internal class Validators
+    internal class ResultValidators
     {
         public static IEnumerable<string> FranchiseValidate(string greeting)
         {

--- a/TestOutputExample/RunHandlers.cs
+++ b/TestOutputExample/RunHandlers.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace DemoHandlers
 {
-    public static class Handlers
+    public static class RunHandlers
     {
         private static void Greet(string greeting, string name)
         {

--- a/TestOutputSimple/GeneratedViaTest/RootCommand.partial.g.cs
+++ b/TestOutputSimple/GeneratedViaTest/RootCommand.partial.g.cs
@@ -10,8 +10,8 @@ namespace Jackfruit
     /// </summary>
     public partial class RootCommand : RootCommand<RootCommand, RootCommand.Result>
     {
-        public new static RootCommand Create(CommandNode cliRoot)
-            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create( cliRoot);
+        public new static RootCommand Create(SubCommand subCommand)
+            => (RootCommand)RootCommand<RootCommand, RootCommand.Result>.Create(subCommand);
 
         public partial class Result
         { }

--- a/TestOutputSimple/Program.cs
+++ b/TestOutputSimple/Program.cs
@@ -1,5 +1,5 @@
 ﻿using Jackfruit;
 using Temp;
 
-var x = RootCommand.Create(CommandNode.Create(Class1.Hello));
+var x = RootCommand.Create(SubCommand.Create(Class1.Hello));
 x.Run(args);


### PR DESCRIPTION
It remains a node, so is this confusing?

Big commit because of many changes and it broke integration tests in an interesting way, so I changed how we skip files when we output from the generated compilation.